### PR TITLE
Fixed: Updated Add cookies after registration of the user

### DIFF
--- a/Frontend/src/components/SignIn.tsx
+++ b/Frontend/src/components/SignIn.tsx
@@ -53,7 +53,7 @@ const SignIn: React.FC = () => {
         }
          appContext.changeLoginState(login_success)
          appContext.changeToken(newtoken)
-        
+        document.cookie = `jwt=${newtoken};path=/` //added cookie using document.cookie
         navigator("/dashboard");
       } 
       else {


### PR DESCRIPTION
Updated fix - Added the cookies after registration / sign-up of the user.

Set the cookie using the core-js module 'document.cookie'
As we were receiving the token from the server
I added the value of the token to a cookie named 'jwt'
Whenever user signs in you can now see the cookies are set in your browser.

fixes #2 
